### PR TITLE
Drop unused "executables" directive from gemspec

### DIFF
--- a/kdl.gemspec
+++ b/kdl.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end + ['lib/kdl/kdl.tab.rb']
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'racc', '~> 1.5'


### PR DESCRIPTION
This gem exposes 0 executables, so we can drop this from the gemspec.