### PR TITLE
CI: use bundler-cache from ruby/setup-ruby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,8 +27,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: gem install bundler && bundle install
+        bundler-cache: true # install and cache dependencies
     - name: Build parser
       run: bundle exec racc lib/kdl/kdl.yy
     - name: Run tests


### PR DESCRIPTION
This PR leverages the bundler-cache feature of the Ruby-maintained Action setup-ruby.

[See ruby/setup-ruby](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.