### PR TITLE
change: drop support for ruby 2.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0, head]
+        ruby: [2.4, 2.5, 2.6, 2.7, 3.0, head]
 
     runs-on: ubuntu-latest
 

--- a/kdl.gemspec
+++ b/kdl.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Ruby implementation of the KDL Document Language Spec}
   spec.homepage      = "https://kdl.dev"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/danini-the-panini/kdl-rb"


### PR DESCRIPTION
Ruby 2.3 reached EOL a while ago already, and it is causing some headaches with some of the breaking changes introduced from 2.4 onwards