### PR TITLE
Fix updated test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 Gemfile.lock
 
 lib/kdl/kdl.tab.rb
+kdl.output

--- a/bin/kdl
+++ b/bin/kdl
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "kdl"
+
+system 'bin/rake racc'
+
+puts KDL.parse_document(ARGF.read).to_s

--- a/lib/kdl/kdl.yy
+++ b/lib/kdl/kdl.yy
@@ -10,13 +10,14 @@ class KDL::Parser
         SEMICOLON
         EOF
         SLASHDASH
+        ESCLINE
 rule
   document  : nodes { KDL::Document.new(val[0]) }
             | linespaces { KDL::Document.new([])}
 
 nodes           : none                      { [] }
-                | linespace_star node       { [val[1]] }
-                | linespace_star empty_node { [] }
+                | linespaces node       { [val[1]] }
+                | linespaces empty_node { [] }
                 | nodes node                { [*val[0], val[1]] }
                 | nodes empty_node          { val[0] }
   node          : untyped_node      { val[0] }
@@ -25,15 +26,15 @@ nodes           : none                      { [] }
                 | node_decl node_children node_term  { val[0].tap { |x| x.children = val[1] } }
                 | node_decl empty_children node_term { val[0].tap { |x| x.children = [] } }
   node_decl     : identifier                              { KDL::Node.new(val[0]) }
-                | node_decl WS value                      { val[0].tap { |x| x.arguments << val[2] } }
-                | node_decl WS SLASHDASH ws_star value    { val[0] }
-                | node_decl WS property                   { val[0].tap { |x| x.properties[val[2][0]] = val[2][1] } }
-                | node_decl WS SLASHDASH ws_star property { val[0] }
+                | node_decl ws value                      { val[0].tap { |x| x.arguments << val[2] } }
+                | node_decl ws SLASHDASH ws_star value    { val[0] }
+                | node_decl ws property                   { val[0].tap { |x| x.properties[val[2][0]] = val[2][1] } }
+                | node_decl ws SLASHDASH ws_star property { val[0] }
   empty_node    : SLASHDASH ws_star node
   node_children : ws_star LBRACE nodes RBRACE { val[2] }
-                | ws_star LBRACE linespace_star RBRACE { [] }
+                | ws_star LBRACE linespaces RBRACE { [] }
   empty_children: SLASHDASH node_children
-                | WS empty_children
+                | ws empty_children
   node_term: linespaces | semicolon_term
   semicolon_term: SEMICOLON | SEMICOLON linespaces
 
@@ -58,10 +59,10 @@ nodes           : none                      { [] }
   boolean : TRUE  { true }
           | FALSE { false }
 
-  ws_star: none | WS
+  ws: WS | ESCLINE | WS ESCLINE | ESCLINE WS | WS ESCLINE WS
+  ws_star: none | ws
   linespace: WS | NEWLINE | EOF
   linespaces: linespace | linespaces linespace
-  linespace_star: none | linespaces
 
   none: { nil }
 

--- a/lib/kdl/kdl.yy
+++ b/lib/kdl/kdl.yy
@@ -21,9 +21,9 @@ nodes           : none                      { [] }
                 | nodes empty_node          { val[0] }
   node          : untyped_node      { val[0] }
                 | type untyped_node { val[1].as_type(val[0], @type_parsers.fetch(val[0], nil)) }
-  untyped_node  : node_decl node_term                { val[0].tap { |x| x.children = nil } }
+  untyped_node  : node_decl node_term                { val[0].tap { |x| x.children = [] } }
                 | node_decl node_children node_term  { val[0].tap { |x| x.children = val[1] } }
-                | node_decl empty_children node_term { val[0].tap { |x| x.children = nil } }
+                | node_decl empty_children node_term { val[0].tap { |x| x.children = [] } }
   node_decl     : identifier                              { KDL::Node.new(val[0]) }
                 | node_decl WS value                      { val[0].tap { |x| x.arguments << val[2] } }
                 | node_decl WS SLASHDASH ws_star value    { val[0] }

--- a/lib/kdl/node.rb
+++ b/lib/kdl/node.rb
@@ -2,7 +2,7 @@ module KDL
   class Node
     attr_accessor :name, :arguments, :properties, :children, :type
 
-    def initialize(name, arguments = [], properties = {}, children = nil, type: nil)
+    def initialize(name, arguments = [], properties = {}, children = [], type: nil)
       @name = name
       @arguments = arguments
       @properties = properties
@@ -19,11 +19,9 @@ module KDL
       unless properties.empty?
         s += " #{properties.map { |k, v| "#{id_to_s k}=#{v}" }.join(' ')}"
       end
-      unless children.nil?
+      unless children.empty?
         s += " {\n"
-        unless children.empty?
-          s += children.map { |c| "#{c.to_s(level + 1)}\n" }.join("\n")
-        end
+        s += children.map { |c| "#{c.to_s(level + 1)}\n" }.join("\n")
         s += "#{indent}}"
       end
       s

--- a/lib/kdl/tokenizer.rb
+++ b/lib/kdl/tokenizer.rb
@@ -358,7 +358,7 @@ module KDL
     end
 
     def parse_float(s)
-      match, _, fraction, exponent = *s.match(/^([-+]?[\d_]+)(?:\.(\d+))?(?:[eE]([-+]?[\d_]+))?$/)
+      match, _, fraction, exponent = *s.match(/^([-+]?[\d_]+)(?:\.([\d_]+))?(?:[eE]([-+]?[\d_]+))?$/)
       raise_error "Invalid floating point value #{s}" if match.nil?
 
       s = munch_underscores(s)

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -8,31 +8,34 @@ class NodeTest < Minitest::Test
   end
 
   def test_nested_to_s
-    value = ::KDL::Node.new("a1", [v("a"), v(1)], {}, [
-      ::KDL::Node.new("b1", [v("b"), v(1)], {}, [
+    value = ::KDL::Node.new("a1", [v("a"), v(1)], { a: v(1) }, [
+      ::KDL::Node.new("b1", [v("b"), v(1, "foo")], {}, [
         ::KDL::Node.new("c1", [v("c"), v(1)])
       ]),
-      ::KDL::Node.new("b2", [v("b"), v(2)], {}, [
+      ::KDL::Node.new("b2", [v("b")], { c: v(2, "bar") }, [
         ::KDL::Node.new("c2", [v("c"), v(2)])
-      ])
+      ]),
+      ::KDL::Node.new("b3", [], {}, [], type: "baz"),
     ])
 
     assert_equal <<~KDL.strip, value.to_s
-      a1 "a" 1 {
-          b1 "b" 1 {
+      a1 "a" 1 a=1 {
+          b1 "b" (foo)1 {
               c1 "c" 1
           }
 
-          b2 "b" 2 {
+          b2 "b" c=(bar)2 {
               c2 "c" 2
           }
+
+          (baz)b3
       }
     KDL
   end
 
   private
 
-  def v(x)
-    ::KDL::Value.from(x)
+  def v(x, t=nil)
+    ::KDL::Value.from(x).then { |v| t ? v.as_type(t) : v }
   end
 end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -36,6 +36,8 @@ class NodeTest < Minitest::Test
   private
 
   def v(x, t=nil)
-    ::KDL::Value.from(x).then { |v| t ? v.as_type(t) : v }
+    val = ::KDL::Value.from(x)
+    return val.as_type(t) if t
+    val
   end
 end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -86,6 +86,15 @@ class ParserTest < Minitest::Test
                  @parser.parse("node /-{\nnode2\n}")
   end
 
+  def test_empty_children
+    assert_equal ::KDL::Document.new([::KDL::Node.new('node')]),
+                 @parser.parse('node {}')
+    assert_equal ::KDL::Document.new([::KDL::Node.new('node')]),
+                 @parser.parse("node {\n  /-node2\n}")
+    assert_equal ::KDL::Document.new([::KDL::Node.new('node')]),
+                 @parser.parse("node /-{\n  node2\n}")
+  end
+
   def test_string
     assert_equal ::KDL::Document.new([::KDL::Node.new('node', [::KDL::Value::String.new("")])]),
                  @parser.parse('node ""')
@@ -397,7 +406,8 @@ class ParserTest < Minitest::Test
     KDL
 
     nodes = nodes! {
-      mynode "not commented"
+      mynode("not commented") {
+      }
     }
     assert_equal nodes, doc
   end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -243,11 +243,9 @@ class ParserTest < Minitest::Test
   end
 
   def test_escline
-    # assert_equal ::KDL::Document.new([::KDL::Node.new('foo')]), @parser.parse("\\\nfoo")
-    # assert_equal ::KDL::Document.new([::KDL::Node.new('foo')]), @parser.parse("\\\n  foo")
-    # assert_equal ::KDL::Document.new([::KDL::Node.new('foo')]), @parser.parse("\\  \t \nfoo")
-    assert_equal ::KDL::Document.new([::KDL::Node.new('foo')]), @parser.parse("\\ // test \nfoo")
-    assert_equal ::KDL::Document.new([::KDL::Node.new('foo')]), @parser.parse("\\ // test \n  foo")
+    assert_equal ::KDL::Document.new([::KDL::Node.new('node', [::KDL::Value.from(1)])]), @parser.parse("node\\\n  1")
+    assert_raises { @parser.parse("node\\\nnode2") }
+    assert_raises { @parser.parse("node\n  \\\n//comment\n  node2") }
   end
 
   def test_whitespace

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ class Minitest::Test
                              args.map { |a| ::KDL::Value.from(a) },
                              kwargs.map { |k, v| [k.to_s, ::KDL::Value.from(v) ]}
                                    .to_h)
-      node.children = block_given? ? Nodes.nodes!(&block) : nil
+      node.children = block_given? ? Nodes.nodes!(&block) : []
       @children << node
     end
     alias _ method_missing

--- a/test/tokenizer_test.rb
+++ b/test/tokenizer_test.rb
@@ -57,6 +57,12 @@ class TokenizerTest < Minitest::Test
     assert_equal t(:WS, "    \t"), ::KDL::Tokenizer.new("    \t").next_token
   end
 
+  def test_escline
+    assert_equal t(:ESCLINE, "\\\n"), ::KDL::Tokenizer.new("\\\n").next_token
+    assert_equal t(:ESCLINE, "\\\n"), ::KDL::Tokenizer.new("\\\n//some comment").next_token
+    assert_equal t(:ESCLINE, "\\\n"), ::KDL::Tokenizer.new("\\\n //some comment").next_token
+  end
+
   def test_multiple_tokens
     tokenizer = ::KDL::Tokenizer.new("node 1 \"two\" a=3")
 
@@ -177,7 +183,9 @@ class TokenizerTest < Minitest::Test
     KDL
 
     assert_equal t(:IDENT, 'title'), tokenizer.next_token
-    assert_equal t(:WS, '   ', 1, 6), tokenizer.next_token
+    assert_equal t(:WS, ' ', 1, 6), tokenizer.next_token
+    assert_equal t(:ESCLINE, "\\\n", 1, 7), tokenizer.next_token
+    assert_equal t(:WS, '  ', 2, 1), tokenizer.next_token
     assert_equal t(:STRING, 'Some title', 2, 3), tokenizer.next_token
     assert_equal t(:NEWLINE, "\n", 2, 15), tokenizer.next_token
     assert_equal t(:EOF, :EOF, 3, 1), tokenizer.next_token


### PR DESCRIPTION
1. Allow underscores in float fractions (https://github.com/kdl-org/kdl/pull/217)O
2. Remove distinction between empty children and no children (https://github.com/kdl-org/kdl/pull/219)
3. Only allow escline between node declaration parts (https://github.com/kdl-org/kdl/pull/226)