### PR TITLE
fix: require uri in url template type

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, 3.0, head]
+        ruby: [2.4, 2.5, 2.6, 2.7, 3.0, 3.1, head]
 
     runs-on: ubuntu-latest
 

--- a/lib/kdl/types/url_template.rb
+++ b/lib/kdl/types/url_template.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module KDL
   module Types
     class URLTemplate < Value


### PR DESCRIPTION
Ruby now doesn't require URI by default