### PR TITLE
fix: allow dash as a node name

### DIFF
--- a/lib/kdl/tokenizer.rb
+++ b/lib/kdl/tokenizer.rb
@@ -120,8 +120,8 @@ module KDL
                              end
             else
               self.context = :decimal
-              traverse(1)
               @buffer = c
+              traverse(1)
             end
           when '\\'
             t = Tokenizer.new(@str, @index + 1)
@@ -341,6 +341,12 @@ module KDL
       return parse_float(s) if s =~ /[.E]/i
 
       token(:INTEGER, Integer(munch_underscores(s), 10), format: '%d')
+    rescue
+      if s[0] =~ INITIAL_IDENTIFIER_CHARS && s[1..-1].each_char.all? { |c| c =~ IDENTIFIER_CHARS }
+        token(:IDENT, s)
+      else
+        raise
+      end
     end
 
     def parse_float(s)

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -441,10 +441,12 @@ class ParserTest < Minitest::Test
     doc = @parser.parse <<~KDL
       "!@#$@$%Q#$%~@!40" "1.2.3" "!!!!!"=true
       foo123~!@#$%^&*.:'|?+ "weeee"
+      - 1
     KDL
     nodes = nodes! {
       _ "!@#$@$%Q#$%~@!40", "1.2.3", "!!!!!": true
       _ "foo123~!@#$%^&*.:'|?+", "weeee"
+      _ "-", 1
     }
     assert_equal nodes, doc
   end

--- a/test/tokenizer_test.rb
+++ b/test/tokenizer_test.rb
@@ -4,6 +4,8 @@ class TokenizerTest < Minitest::Test
   def test_identifier
     assert_equal t(:IDENT, "foo"), ::KDL::Tokenizer.new("foo").next_token
     assert_equal t(:IDENT, "foo-bar123"), ::KDL::Tokenizer.new("foo-bar123").next_token
+    assert_equal t(:IDENT, "-"), ::KDL::Tokenizer.new("-").next_token
+    assert_equal t(:IDENT, "--"), ::KDL::Tokenizer.new("--").next_token
   end
 
   def test_string


### PR DESCRIPTION
Allows "-" as a node name, previously this would fail as the tokenizer was trying to parse it as an Integer. The solution is to allow invalid numbers as identifiers if they follow the identifier pattern