### PR TITLE
small fixes

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,9 +15,10 @@ on:
 
 jobs:
   test:
+    continue-on-error: ${{ matrix.ruby == 'head' }}
     strategy:
       matrix:
-        ruby: [3.1, 3.2, 3.3, head]
+        ruby: [3.1, 3.2, 3.3, 3.4, head]
 
     runs-on: ubuntu-latest
 

--- a/lib/kdl/kdl.yy
+++ b/lib/kdl/kdl.yy
@@ -43,7 +43,7 @@ rule
   empty_childrens: empty_children | empty_childrens empty_children
   node_term: linespaces | semicolon_term
   semicolon_term: SEMICOLON | SEMICOLON linespaces
-  slashdash: SLASHDASH | slashdash ws_plus | slashdash linespaces
+  slashdash: SLASHDASH | slashdash linespaces
 
   type : LPAREN ws_star identifier ws_star RPAREN ws_star { val[2] }
 

--- a/lib/kdl/kdl.yy
+++ b/lib/kdl/kdl.yy
@@ -21,12 +21,12 @@ rule
   node           : unterm_node node_term       { val[0] }
   unterm_node    : untyped_node      { val[0] }
                  | type untyped_node { val[1].as_type(val[0], @type_parsers.fetch(val[0], nil)) }
-  untyped_node   : node_decl                                               { val[0].tap { |x| x.children = [] } }
-                 | node_decl node_children                                 { val[0].tap { |x| x.children = val[1] } }
-                 | node_decl empty_childrens                               { val[0].tap { |x| x.children = [] } }
-                 | node_decl empty_childrens node_children                 { val[0].tap { |x| x.children = val[2] } }
-                 | node_decl node_children empty_childrens                 { val[0].tap { |x| x.children = val[1] } }
-                 | node_decl empty_childrens node_children empty_childrens { val[0].tap { |x| x.children = val[2] } }
+  untyped_node   : node_decl                                                       { val[0].tap { |x| x.children = [] } }
+                 | node_decl ws_plus node_children                                 { val[0].tap { |x| x.children = val[2] } }
+                 | node_decl ws_plus empty_childrens                               { val[0].tap { |x| x.children = [] } }
+                 | node_decl ws_plus empty_childrens node_children                 { val[0].tap { |x| x.children = val[3] } }
+                 | node_decl ws_plus node_children empty_childrens                 { val[0].tap { |x| x.children = val[2] } }
+                 | node_decl ws_plus empty_childrens node_children empty_childrens { val[0].tap { |x| x.children = val[3] } }
   node_decl      : identifier                           { @output_module::Node.new(val[0]) }
                  | node_decl ws_plus value              { val[0].tap { |x| x.arguments << val[2] } }
                  | node_decl ws_plus slashdash value    { val[0] }

--- a/lib/kdl/tokenizer.rb
+++ b/lib/kdl/tokenizer.rb
@@ -42,16 +42,16 @@ module KDL
       '=' => :EQUALS
     }
 
-    WHITESPACE = ["\u0009", "\u000B", "\u0020", "\u00A0",
-                  "\u1680", "\u2000", "\u2001", "\u2002",
-                  "\u2003", "\u2004", "\u2005", "\u2006",
-                  "\u2007", "\u2008", "\u2009", "\u200A",
-                  "\u202F", "\u205F", "\u3000" ]
+    WHITESPACE = ["\u0009", "\u0020", "\u00A0", "\u1680",
+                  "\u2000", "\u2001", "\u2002", "\u2003",
+                  "\u2004", "\u2005", "\u2006", "\u2007",
+                  "\u2008", "\u2009", "\u200A", "\u202F",
+                  "\u205F", "\u3000"]
     WS = "[#{Regexp.escape(WHITESPACE.join)}]"
     WS_STAR = /\A#{WS}*\z/
     WS_PLUS = /\A#{WS}+\z/
 
-    NEWLINES = ["\u000A", "\u0085", "\u000C", "\u2028", "\u2029"]
+    NEWLINES = ["\u000A", "\u0085", "\u000B", "\u000C", "\u2028", "\u2029"]
     NEWLINES_PATTERN = Regexp.new("(#{NEWLINES.map{Regexp.escape(_1)}.join('|')}|\r\n?)", Regexp::MULTILINE)
 
     OTHER_NON_IDENTIFIER_CHARS = ("\x0".."\x20").to_a - WHITESPACE
@@ -70,6 +70,8 @@ module KDL
       "\uFEFF"
     ]
 
+    VERSION_PATTERN = /\A\/-[#{WHITESPACE.join}]*kdl-version[#{WHITESPACE.join}]+(\d+)[#{WHITESPACE.join}]*[#{NEWLINES.join}]/
+
     def initialize(str, start = 0)
       @str = debom(str)
       @context = nil
@@ -86,7 +88,7 @@ module KDL
     end
 
     def version_directive
-      if m = @str.match(/\A\/-[#{WHITESPACE.join}]*kdl-version[#{WHITESPACE.join}]+(\d+)\s*[#{NEWLINES.join}]/)
+      if m = @str.match(VERSION_PATTERN)
         m[1].to_i
       end
     end
@@ -633,9 +635,9 @@ module KDL
       end
       return "" if lines.empty?
       raise_error "Invalid multiline string final line" unless indent.match?(WS_STAR)
-      valid = /\A(?:#{Regexp.escape(indent)})(.*)/
+      valid = /\A#{Regexp.escape(indent)}(.*)/
 
-      lines.map! do |line|
+      lines.map do |line|
         case line
         when WS_STAR then ""
         when valid then $1

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -56,7 +56,7 @@ class ParserTest < Minitest::Test
     assert_equal ::KDL::Document.new([]), @parser.parse("/- node\n")
     assert_equal ::KDL::Document.new([]), @parser.parse('/-node 1 2 3')
     assert_equal ::KDL::Document.new([]), @parser.parse('/-node key=#false')
-    assert_equal ::KDL::Document.new([]), @parser.parse("/-node{\nnode\n}")
+    assert_equal ::KDL::Document.new([]), @parser.parse("/-node {\nnode\n}")
     assert_equal ::KDL::Document.new([]), @parser.parse("/-node 1 2 3 key=\"value\" \\\n{\nnode\n}")
   end
 

--- a/test/spec_test.rb
+++ b/test/spec_test.rb
@@ -17,7 +17,8 @@ class SpecTest < Minitest::Test
       end
     else
       define_method "test_#{input_name}_does_not_parse" do
-        assert_raises { ::KDL.load_file(input_path, version: 2) }
+        err = assert_raises { ::KDL.load_file(input_path, version: 2) }
+        raise err unless err.is_a?(KDL::Error) || err.is_a?(Racc::ParseError)
       end
     end
   end

--- a/test/v1/spec_test.rb
+++ b/test/v1/spec_test.rb
@@ -22,7 +22,8 @@ class KDL::V1::SpecTest < Minitest::Test
     end
     else
       define_method "test_v1_#{input_name}_does_not_parse" do
-        assert_raises { ::KDL.load_file(input_path, version: 1) }
+        err = assert_raises { ::KDL.load_file(input_path, version: 1) }
+        raise err unless err.is_a?(KDL::Error) || err.is_a?(Racc::ParseError)
       end
     end
   end


### PR DESCRIPTION
1. remove superfluous slashdash whitespace parse rule
2. move vertical tab from whitespace to newline
3. fix whitespace in version directive pattern
4. remove superfluous bang
5. explicit check for unicode surrogates
6. make sure tokenizer converts errors to Tokenizer::Error if they aren't
7. require whitespace before children
8. add ruby 3.4 to ci matrix, allow `head` to fail