### PR TITLE
Bugfix: `false` must be quoted

### DIFF
--- a/lib/kdl/string_dumper.rb
+++ b/lib/kdl/string_dumper.rb
@@ -32,7 +32,7 @@ module KDL
 
     def bare_identifier?(name)
       case name
-      when '', 'true', 'fase', 'null', '#true', '#false', '#null', /\A\.?\d/
+      when '', 'true', 'false', 'null', '#true', '#false', '#null', /\A\.?\d/
         false
       else
         !name.each_char.any? { |c| FORBIDDEN.include?(c) }

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -14,6 +14,7 @@ class ValueTest < Minitest::Test
     assert_equal "#null", ::KDL::Value::Null.to_s
     assert_equal 'foo', ::KDL::Value::String.new("foo").to_s
     assert_equal '"foo \"bar\" baz"', ::KDL::Value::String.new('foo "bar" baz').to_s
+    assert_equal '"false"', ::KDL::Value::String.new("false").to_s
     assert_equal '(ty)foo', ::KDL::Value::String.new("foo", type: 'ty').to_s
   end
 


### PR DESCRIPTION
Due to the typo in `StringDumper#bare_identifier?`, `false` was being serialized without quotes, which is invalid KDLv2.