### PR TITLE
Tweak dev setup for reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ KDL.parse("/- kdl-version 2\nfoo bar", version: 1)
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bin/rake install`. To release a new version, update the version number in `version.rb`, and then run `bin/rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/bin/setup
+++ b/bin/setup
@@ -7,3 +7,4 @@ bundle install
 
 # Do any other automated setup that you need to do here
 bin/rake racc
+git submodule update --init --recursive


### PR DESCRIPTION
* Sync git submodules in bin/setup as they are required for specs to pass
* bundle exec rake spec so as not to rely on whatever version of rake happens to be lying around in the users $PATH