### PR TITLE
Drop Ruby 3.1 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
     continue-on-error: ${{ matrix.ruby == 'head' }}
     strategy:
       matrix:
-        ruby: [3.1, 3.2, 3.3, 3.4, head]
+        ruby: [3.2, 3.3, 3.4, 4.0, head]
 
     runs-on: ubuntu-latest
 

--- a/kdl.gemspec
+++ b/kdl.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Ruby implementation of the KDL Document Language Spec}
   spec.homepage      = "https://kdl.dev"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.2.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/danini-the-panini/kdl-rb"


### PR DESCRIPTION
Ruby 3.1 has been EOL for over a year. Dropping support so we can upgrade to Minitest 6 (#35)

Also adding Ruby 4.0 to the test matrix.